### PR TITLE
fix samples conf file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,27 @@
 
 1. Start the seata-server service with the docker file under the /dockercomposer folder
 
-   ````shell
+   ```shell
    git clone https://github.com/seata/seata-go-samples.git
-   ````
-   ````shell
+   ```
+
+   ```shell
    cd dockercompose
-   ````
-   ````shell
+   ```
+
+   ```shell
    docker-compose -f docker-compose.yml up -d seata-server
-   ````
+   ```
 
 2. Start and run a sample, for example let's run a basic distributed transaction sample of AT
 
-   ````shell
+   ```shell
    cd at/basic
-   ````
-   ````shell
-   go run main.go
-   ````
+   ```
+
+   ```shell
+   go run .
+   ```
 
 ### Customize mysql connection configurations
 
@@ -30,6 +33,7 @@ The default mysql connection configuration is suitable with dockercompose/docker
 You can also customize it by system environment.
 
 System Env Supported:
+
 1. MYSQL_HOST
 2. MYSQL_PORT
 3. MYSQL_USERNAME
@@ -41,35 +45,35 @@ System Env Supported:
 1. Modify the seata-go dependency version to v0.0.0-incompatible, and remove the version number if it exists in the
    original dependency path.
 
-   ````
+   ```
    //github.com/seata/seata-go v1.0.3
    github.com/seata/seata-go v0.0.0-incompatibl
-   ````
+   ```
 
 2. Find the absolute or relative path to your local code.
 
-   ````
+   ```
    /Users/mac/Desktop/GO/seata-go
    ../seata-go
-   ````
+   ```
 
 3. Add the replace module to the go.mod file and change it to the local code path.
 
-   ````
+   ```
    github.com/seata/seata-go =>  ../seata-go
-   ````
+   ```
 
 4. Synchronization dependencies.
 
-   ````shell
+   ```shell
    go mod tidy
-   ````
+   ```
 
 5. Run the sample test code.
 
 ## How to use go workspace to test samples for new PR (Recommended)
 
-You can use your local project forked to test new pr that haven't merged into github.com/seata/seata-go. 
+You can use your local project forked to test new pr that haven't merged into github.com/seata/seata-go.
 
 1. Make sure your go version is 1.18 or later.
 
@@ -77,42 +81,42 @@ You can use your local project forked to test new pr that haven't merged into gi
 
 For examples:
 
-````text
+```text
 /Users/xxx/code/github.com/yourid/seata-go
 /Users/xxx/code/github.com/yourid/seata-go-samples
-````
+```
 
 3. Execute go work init command in projects root directory.
 
-````shell
+```shell
 cd /Users/xxx/code/github.com/yourid
-````
+```
 
-````shell
+```shell
 go work init
-````
+```
 
 You will find a go.work file in /Users/xxx/code/github.com/yourid.
 
 4. Add seata-go and seata-go-samples into the same go workspace.
 
-````shell
+```shell
 go work use ./seata-go
-````
+```
 
-````shell
+```shell
 go work use ./seata-go-samples
-````
+```
 
 Now, the content of go.work file is as follows.
 
-````text
+```text
 go 1.19
 
 use (
         ./seata-go
         ./seata-go-samples
 )
-````
+```
 
 5. Run the sample test code in seata-go-samples.

--- a/at/basic/main.go
+++ b/at/basic/main.go
@@ -30,7 +30,7 @@ import (
 var db *sql.DB
 
 func main() {
-	client.InitPath("./conf/seatago.yml")
+	client.InitPath("../../conf/seatago.yml")
 	db = util.GetAtMySqlDb()
 	ctx := context.Background()
 

--- a/at/gin/client/main.go
+++ b/at/gin/client/main.go
@@ -29,7 +29,7 @@ var serverIpPort = "http://127.0.0.1:8080"
 
 func main() {
 	flag.Parse()
-	client.InitPath("./conf/seatago.yml")
+	client.InitPath("../../../conf/seatago.yml")
 
 	bgCtx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
 	defer cancel()

--- a/at/gin/server/main.go
+++ b/at/gin/server/main.go
@@ -31,7 +31,7 @@ import (
 var db *sql.DB
 
 func main() {
-	client.InitPath("./conf/seatago.yml")
+	client.InitPath("../../../conf/seatago.yml")
 	db = util.GetAtMySqlDb()
 
 	r := gin.Default()

--- a/at/gorm/main.go
+++ b/at/gorm/main.go
@@ -50,7 +50,7 @@ func main() {
 
 func initConfig() {
 	// init seata client config
-	client.InitPath("./conf/seatago.yml")
+	client.InitPath("../../conf/seatago.yml")
 	// init db object
 	initDB()
 }

--- a/at/non_transaction/main.go
+++ b/at/non_transaction/main.go
@@ -46,7 +46,7 @@ var (
 var db *sql.DB
 
 func main() {
-	client.InitPath("./conf/seatago.yml")
+	client.InitPath("../../conf/seatago.yml")
 	db = util.GetAtMySqlDb()
 
 	insertId := insertData()

--- a/at/rollback/client/main.go
+++ b/at/rollback/client/main.go
@@ -32,7 +32,7 @@ var (
 
 func main() {
 	flag.Parse()
-	client.InitPath("./conf/seatago.yml")
+	client.InitPath("../../../conf/seatago.yml")
 
 	bgCtx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
 	defer cancel()

--- a/at/rollback/server/main.go
+++ b/at/rollback/server/main.go
@@ -31,7 +31,7 @@ import (
 var db *sql.DB
 
 func main() {
-	client.InitPath("./conf/seatago.yml")
+	client.InitPath("../../../conf/seatago.yml")
 	db = util.GetAtMySqlDb()
 
 	r := gin.Default()

--- a/at/rollback/server2/main.go
+++ b/at/rollback/server2/main.go
@@ -31,7 +31,7 @@ import (
 var db *sql.DB
 
 func main() {
-	client.InitPath("./conf/seatago.yml")
+	client.InitPath("../../../conf/seatago.yml")
 	db = util.GetAtMySqlDb()
 
 	r := gin.Default()

--- a/tcc/dubbo/client/cmd/client.go
+++ b/tcc/dubbo/client/cmd/client.go
@@ -31,7 +31,7 @@ import (
 
 // need to setup environment variable "DUBBO_GO_CONFIG_PATH" to "conf/dubbogo.yml" before run
 func main() {
-	client.InitPath("./sample/conf/seatago.yml")
+	client.InitPath("../../../../conf/seatago.yml")
 	config.SetConsumerService(service.UserProviderInstance)
 	if err := config.Load(); err != nil {
 		panic(err)

--- a/tcc/dubbo/server/cmd/server.go
+++ b/tcc/dubbo/server/cmd/server.go
@@ -35,7 +35,7 @@ import (
 
 // need to setup environment variable "DUBBO_GO_CONFIG_PATH" to "conf/dubbogo.yml" before run
 func main() {
-	client.InitPath("./sample/conf/seatago.yml")
+	client.InitPath("../../../../conf/seatago.yml")
 	userProviderProxy, err := tcc.NewTCCServiceProxy(&service.UserProvider{})
 	if err != nil {
 		log.Errorf("get userProviderProxy tcc service proxy error, %v", err.Error())

--- a/tcc/fence/cmd/main.go
+++ b/tcc/fence/cmd/main.go
@@ -29,7 +29,7 @@ import (
 )
 
 func main() {
-	client.InitPath("./sample/conf/seatago.yml")
+	client.InitPath("../../../conf/seatago.yml")
 	tm.WithGlobalTx(context.Background(), &tm.GtxConfig{
 		Name: "TccSampleLocalGlobalTx",
 	}, business)

--- a/tcc/gin/client/main.go
+++ b/tcc/gin/client/main.go
@@ -32,7 +32,7 @@ import (
 
 func main() {
 	flag.Parse()
-	client.InitPath("./sample/conf/seatago.yml")
+	client.InitPath("../../../conf/seatago.yml")
 	bgCtx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
 	defer cancel()
 	serverIpPort := "http://127.0.0.1:8080"

--- a/tcc/gin/server/main.go
+++ b/tcc/gin/server/main.go
@@ -29,7 +29,7 @@ import (
 )
 
 func main() {
-	client.InitPath("./sample/conf/seatago.yml")
+	client.InitPath("../../../conf/seatago.yml")
 
 	r := gin.Default()
 

--- a/tcc/grpc/cmd/client/main.go
+++ b/tcc/grpc/cmd/client/main.go
@@ -45,7 +45,8 @@ func main() {
 	defer conn.Close()
 	c1, c2 := pb.NewTCCServiceBusiness1Client(conn), pb.NewTCCServiceBusiness2Client(conn)
 
-	client.InitPath("./conf/seatago.yml")
+	client.InitPath("../../../../conf/seatago.yml")
+
 	tm.WithGlobalTx(
 		context.Background(),
 		&tm.GtxConfig{

--- a/tcc/grpc/cmd/server/main.go
+++ b/tcc/grpc/cmd/server/main.go
@@ -33,7 +33,7 @@ import (
 )
 
 func main() {
-	client.InitPath("./conf/seatago.yml")
+	client.InitPath("../../../../conf/seatago.yml")
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", 50051))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)

--- a/tcc/local/cmd/local.go
+++ b/tcc/local/cmd/local.go
@@ -27,7 +27,7 @@ import (
 )
 
 func main() {
-	client.InitPath("./sample/conf/seatago.yml")
+	client.InitPath("../../../conf/seatago.yml")
 	tm.WithGlobalTx(context.Background(), &tm.GtxConfig{
 		Name: "TccSampleLocalGlobalTx",
 	}, business)

--- a/tcc/propagation/first/main.go
+++ b/tcc/propagation/first/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 func main() {
-	client.InitPath("./sample/conf/seatago.yml")
+	client.InitPath("../../../conf/seatago.yml")
 	log.Info(tm.WithGlobalTx(context.Background(), &tm.GtxConfig{
 		Name: "TccSampleLocalGlobalTxFirst",
 	}, business))

--- a/xa/basic/main.go
+++ b/xa/basic/main.go
@@ -30,7 +30,7 @@ import (
 var db *sql.DB
 
 func main() {
-	client.InitPath("./conf/seatago.yml")
+	client.InitPath("../../conf/seatago.yml")
 	db = util.GetXAMySqlDb()
 	ctx := context.Background()
 

--- a/xa/gin/client/main.go
+++ b/xa/gin/client/main.go
@@ -29,7 +29,7 @@ var serverIpPort = "http://127.0.0.1:8080"
 
 func main() {
 	flag.Parse()
-	client.InitPath("./conf/seatago.yml")
+	client.InitPath("../../../conf/seatago.yml")
 
 	bgCtx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
 	defer cancel()

--- a/xa/gin/server/main.go
+++ b/xa/gin/server/main.go
@@ -31,7 +31,7 @@ import (
 var db *sql.DB
 
 func main() {
-	client.InitPath("./conf/seatago.yml")
+	client.InitPath("../../../conf/seatago.yml")
 	db = util.GetXAMySqlDb()
 
 	r := gin.Default()

--- a/xa/gorm/main.go
+++ b/xa/gorm/main.go
@@ -50,7 +50,7 @@ func main() {
 
 func initConfig() {
 	// init seata client config
-	client.InitPath("./conf/seatago.yml")
+	client.InitPath("../../conf/seatago.yml")
 	// init db object
 	initDB()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**:
Fix conf file path at directory `at`, and the start command `go run main.go` to start basic app at `README.md`

**Which issue(s) this PR fixes**:

https://github.com/apache/incubator-seata-go-samples/issues/45

**The related PR of seata-go** 
None
