### PR TITLE
update depreciated undo log-serialization config

### DIFF
--- a/conf/seatago.yml
+++ b/conf/seatago.yml
@@ -59,7 +59,7 @@ seata:
       # Judge whether the before image and after image are the same，If it is the same, undo will not be recorded
       data-validation: true
       # Serialization method
-      log-serialization: jackson
+      log-serialization: json
       # undo log table name
       log-table: undo_log
       # Only store modified fields


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**:

undo config log-serialization `jackson` is depreciated, change it to default `json`

**Which issue(s) this PR fixes**:
Fixes #

**The related PR of seata-go** 

https://github.com/apache/incubator-seata-go/pull/653