### PR TITLE
chore:change undolog serializetion in seatago.yml

### DIFF
--- a/conf/seatago.yml
+++ b/conf/seatago.yml
@@ -59,7 +59,7 @@ seata:
       # Judge whether the before image and after image are the same，If it is the same, undo will not be recorded
       data-validation: true
       # Serialization method
-      log-serialization: jackson
+      log-serialization: json
       # undo log table name
       log-table: undo_log
       # Only store modified fields


### PR DESCRIPTION
Change the default serialization for undolog.
Because the current seata-go does not support Jackson serialization

https://github.com/apache/incubator-seata-go/blob/master/pkg/datasource/sql/undo/parser/parser_cache.go#L36-L43


**The related PR of seata-go** 
https://github.com/apache/incubator-seata-go/pull/690
